### PR TITLE
Add support for stable rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,13 @@ edition = "2018"
 license = "MIT/Apache-2.0"
 
 repository = "https://github.com/vcombey/fallible_collections.git"
-description = "a crate wich add fallible allocation api to std collections"
+description = "a crate which adds fallible allocation api to std collections"
 readme = "README.md"
 keywords = ["fallible", "collections"]
+
+[dependencies]
+hashbrown = "0.7.1"
+
+[features]
+# Enable on nightly builds to allow use of unstable features
+unstable = []

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -2,8 +2,8 @@
 use super::FallibleBox;
 use super::TryClone;
 
+use crate::TryReserveError;
 use alloc::boxed::Box;
-use alloc::collections::TryReserveError;
 use alloc::sync::Arc;
 
 /// trait to implement Fallible Arc
@@ -25,7 +25,7 @@ impl<T> FallibleArc<T> for Arc<T> {
 
 /// Just a TryClone boilerplate for Arc
 impl<T: ?Sized> TryClone for Arc<T> {
-    fn try_clone(&self) -> Result<Self, alloc::collections::TryReserveError> {
+    fn try_clone(&self) -> Result<Self, TryReserveError> {
         Ok(self.clone())
     }
 }

--- a/src/btree.rs
+++ b/src/btree.rs
@@ -1,4 +1,5 @@
 //! Implement Fallible Btree, As there is no try_reserve methods on btree, I add no choice but to fork the std implementation and change return types.
+//! Currently this functionality is only available when building this crate with nightly and the `unstable` feature.
 pub mod map;
 pub use map::BTreeMap;
 
@@ -7,7 +8,7 @@ pub use set::BTreeSet;
 
 mod node;
 mod search;
-use alloc::collections::TryReserveError;
+use crate::TryReserveError;
 
 #[doc(hidden)]
 trait Recover<Q: ?Sized> {

--- a/src/btree/map.rs
+++ b/src/btree/map.rs
@@ -1,4 +1,4 @@
-use alloc::collections::TryReserveError;
+use crate::TryReserveError;
 use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::fmt::Debug;

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -37,9 +37,9 @@ use core::ptr::{self, NonNull, Unique};
 use core::slice;
 
 use crate::boxed::FallibleBox;
+use crate::TryReserveError;
 use alloc::alloc::{AllocRef, Global, Layout};
 use alloc::boxed::Box;
-use alloc::collections::TryReserveError;
 
 const B: usize = 6;
 pub const MIN_LEN: usize = B - 1;

--- a/src/btree/set.rs
+++ b/src/btree/set.rs
@@ -1,7 +1,7 @@
 // This is pretty much entirely stolen from TreeSet, since BTreeMap has an identical interface
 // to TreeMap
 
-use alloc::collections::TryReserveError;
+use crate::TryReserveError;
 use core::borrow::Borrow;
 use core::cmp::max;
 use core::cmp::Ordering::{self, Equal, Greater, Less};

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,6 +1,6 @@
 //! A try_format! macro replacing format!
 use super::FallibleVec;
-use alloc::collections::TryReserveError;
+use crate::TryReserveError;
 use alloc::fmt::{Arguments, Write};
 use alloc::string::String;
 use alloc::vec::Vec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,17 +3,16 @@
 //! This was used in the turbofish OS hobby project to mitigate the
 //! the lack of faillible allocation in rust.
 #![cfg_attr(not(test), no_std)]
-#![feature(try_reserve)]
-#![feature(specialization)]
-#![feature(allocator_api)]
-#![feature(dropck_eyepatch)]
-#![feature(ptr_internals)]
-#![feature(core_intrinsics)]
-#![feature(maybe_uninit_ref)]
-#![feature(maybe_uninit_slice)]
-#![feature(maybe_uninit_extra)]
-#![feature(internal_uninit_const)]
-
+#![cfg_attr(feature = "unstable", feature(try_reserve))]
+#![cfg_attr(feature = "unstable", feature(specialization))]
+#![cfg_attr(feature = "unstable", feature(allocator_api))]
+#![cfg_attr(feature = "unstable", feature(dropck_eyepatch))]
+#![cfg_attr(feature = "unstable", feature(ptr_internals))]
+#![cfg_attr(feature = "unstable", feature(core_intrinsics))]
+#![cfg_attr(feature = "unstable", feature(maybe_uninit_ref))]
+#![cfg_attr(feature = "unstable", feature(maybe_uninit_slice))]
+#![cfg_attr(feature = "unstable", feature(maybe_uninit_extra))]
+#![cfg_attr(feature = "unstable", feature(internal_uninit_const))]
 extern crate alloc;
 
 pub mod boxed;
@@ -25,12 +24,16 @@ pub mod rc;
 pub use rc::*;
 pub mod arc;
 pub use arc::*;
+#[cfg(feature = "unstable")]
 pub mod btree;
 #[macro_use]
 pub mod format;
 pub mod try_clone;
 
+#[cfg(feature = "unstable")]
 use alloc::collections::TryReserveError;
+#[cfg(not(feature = "unstable"))]
+use hashbrown::CollectionAllocErr as TryReserveError;
 
 /// trait for trying to clone an elem, return an error instead of
 /// panic if allocation failed

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -1,7 +1,7 @@
 //! Implement a Fallible Rc
 use super::FallibleBox;
+use crate::TryReserveError;
 use alloc::boxed::Box;
-use alloc::collections::TryReserveError;
 use alloc::rc::Rc;
 /// trait to implement Fallible Rc
 pub trait FallibleRc<T> {

--- a/src/try_clone.rs
+++ b/src/try_clone.rs
@@ -1,7 +1,7 @@
 //! this module implements try clone for primitive rust types
 
 use super::TryClone;
-use alloc::collections::TryReserveError;
+use crate::TryReserveError;
 
 macro_rules! impl_try_clone {
     ($($e: ty),*) => {

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1,8 +1,11 @@
 //! Implement Fallible Vec
 use super::TryClone;
-use alloc::collections::TryReserveError;
+use crate::TryReserveError;
+#[cfg(not(feature = "unstable"))]
+use alloc::alloc::{alloc, realloc, Layout};
 use alloc::vec::Vec;
 
+#[cfg(feature = "unstable")]
 #[macro_export]
 /// macro trying to create a vec, return a
 /// Result<Vec<T>,TryReserveError>
@@ -53,16 +56,88 @@ pub trait FallibleVec<T> {
         T: TryClone;
 }
 
+#[cfg(not(feature = "unstable"))]
+fn vec_try_reserve<T>(v: &mut Vec<T>, additional: usize) -> Result<(), TryReserveError> {
+    let available = v.capacity().checked_sub(v.len()).expect("capacity >= len");
+    if additional > available {
+        let increase = additional
+            .checked_sub(available)
+            .expect("additional > available");
+        let new_cap = v
+            .capacity()
+            .checked_add(increase)
+            .ok_or(TryReserveError::CapacityOverflow)?;
+        vec_try_extend(v, new_cap)?;
+        debug_assert!(v.capacity() == new_cap);
+    }
+
+    Ok(())
+}
+
+#[cfg(not(feature = "unstable"))]
+fn vec_try_extend<T>(v: &mut Vec<T>, new_cap: usize) -> Result<(), TryReserveError> {
+    let old_len = v.len();
+    let old_cap: usize = v.capacity();
+
+    if old_cap >= new_cap {
+        return Ok(());
+    }
+
+    let elem_size = core::mem::size_of::<T>();
+    let new_alloc_size = new_cap
+        .checked_mul(elem_size)
+        .ok_or(TryReserveError::CapacityOverflow)?;
+
+    // required for alloc safety
+    // See https://doc.rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html#safety-1
+    // Should be unreachable given prior `old_cap >= new_cap` check.
+    assert!(new_alloc_size > 0);
+
+    let align = core::mem::align_of::<T>();
+
+    let (new_ptr, layout) = {
+        if old_cap == 0 {
+            let layout = Layout::from_size_align(new_alloc_size, align).expect("Invalid layout");
+            let new_ptr = unsafe { alloc(layout) };
+            (new_ptr, layout)
+        } else {
+            let old_alloc_size = old_cap
+                .checked_mul(elem_size)
+                .ok_or(TryReserveError::CapacityOverflow)?;
+            let layout = Layout::from_size_align(old_alloc_size, align).expect("Invalid layout");
+            let new_ptr = unsafe { realloc(v.as_mut_ptr() as *mut u8, layout, new_alloc_size) };
+            (new_ptr, layout)
+        }
+    };
+
+    if new_ptr.is_null() {
+        return Err(TryReserveError::AllocErr { layout });
+    }
+
+    let new_vec = unsafe { Vec::from_raw_parts(new_ptr.cast(), old_len, new_cap) };
+
+    core::mem::forget(core::mem::replace(v, new_vec));
+    Ok(())
+}
+
 impl<T> FallibleVec<T> for Vec<T> {
     fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
-        self.try_reserve(additional)
+        #[cfg(feature = "unstable")]
+        {
+            self.try_reserve(additional)
+        }
+
+        #[cfg(not(feature = "unstable"))]
+        {
+            vec_try_reserve(self, additional)
+        }
     }
     fn try_push(&mut self, elem: T) -> Result<(), TryReserveError> {
-        self.try_reserve(1)?;
+        FallibleVec::try_reserve(self, 1)?;
         Ok(self.push(elem))
     }
     fn try_push_give_back(&mut self, elem: T) -> Result<(), (T, TryReserveError)> {
-        if let Err(e) = self.try_reserve(1) {
+        if let Err(e) = FallibleVec::try_reserve(self, 1) {
             return Err((elem, e));
         }
         Ok(self.push(elem))
@@ -72,18 +147,18 @@ impl<T> FallibleVec<T> for Vec<T> {
         Self: core::marker::Sized,
     {
         let mut n = Self::new();
-        n.try_reserve(capacity)?;
+        FallibleVec::try_reserve(&mut n, capacity)?;
         Ok(n)
     }
 
     fn try_insert(&mut self, index: usize, element: T) -> Result<(), (T, TryReserveError)> {
-        if let Err(e) = self.try_reserve(1) {
+        if let Err(e) = FallibleVec::try_reserve(self, 1) {
             return Err((element, e));
         }
         Ok(self.insert(index, element))
     }
     fn try_append(&mut self, other: &mut Self) -> Result<(), TryReserveError> {
-        self.try_reserve(other.len())?;
+        FallibleVec::try_reserve(self, other.len())?;
         Ok(self.append(other))
     }
     fn try_resize(&mut self, new_len: usize, value: T) -> Result<(), TryReserveError>
@@ -92,7 +167,7 @@ impl<T> FallibleVec<T> for Vec<T> {
     {
         let len = self.len();
         if new_len > len {
-            self.try_reserve(new_len - len)?;
+            FallibleVec::try_reserve(self, new_len - len)?;
         }
         Ok(self.resize(new_len, value))
     }
@@ -112,7 +187,7 @@ impl<T> FallibleVec<T> for Vec<T> {
     where
         T: Copy + Clone,
     {
-        self.try_reserve(other.len())?;
+        FallibleVec::try_reserve(self, other.len())?;
         Ok(self.extend_from_slice(other))
     }
     fn try_extend_from_slice_no_copy(&mut self, other: &[T]) -> Result<(), TryReserveError>
@@ -120,7 +195,7 @@ impl<T> FallibleVec<T> for Vec<T> {
         T: TryClone,
     {
         let mut len = self.len();
-        self.try_reserve(other.len())?;
+        FallibleVec::try_reserve(self, other.len())?;
         let mut iterator = other.iter();
         while let Some(element) = iterator.next() {
             unsafe {
@@ -164,7 +239,7 @@ impl<T> TryExtend<T> for Vec<T> {
         n: usize,
         mut value: E,
     ) -> Result<(), TryReserveError> {
-        self.try_reserve(n)?;
+        FallibleVec::try_reserve(self, n)?;
 
         unsafe {
             let mut ptr = self.as_mut_ptr().add(self.len());
@@ -219,15 +294,18 @@ impl<T> Truncate for Vec<T> {
 }
 
 /// try creating a vec from an `elem` cloned `n` times, see std::from_elem
+#[cfg(feature = "unstable")]
 pub fn try_from_elem<T: TryClone>(elem: T, n: usize) -> Result<Vec<T>, TryReserveError> {
     <T as SpecFromElem>::try_from_elem(elem, n)
 }
 
 // Specialization trait used for Vec::from_elem
+#[cfg(feature = "unstable")]
 trait SpecFromElem: Sized {
     fn try_from_elem(elem: Self, n: usize) -> Result<Vec<Self>, TryReserveError>;
 }
 
+#[cfg(feature = "unstable")]
 impl<T: TryClone> SpecFromElem for T {
     default fn try_from_elem(elem: Self, n: usize) -> Result<Vec<T>, TryReserveError> {
         let mut v = Vec::new();
@@ -236,6 +314,7 @@ impl<T: TryClone> SpecFromElem for T {
     }
 }
 
+#[cfg(feature = "unstable")]
 impl SpecFromElem for u8 {
     #[inline]
     fn try_from_elem(elem: u8, n: usize) -> Result<Vec<u8>, TryReserveError> {
@@ -292,7 +371,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
     #[test]
+    #[cfg(feature = "unstable")]
     fn vec() {
         // let v: Vec<u8> = from_elem(1, 10);
         let v: Vec<Vec<u8>> = try_vec![try_vec![42; 10].unwrap(); 100].unwrap();
@@ -301,6 +382,7 @@ mod tests {
         println!("{:?}", v2);
         assert_eq!(2 + 2, 4);
     }
+
     #[test]
     fn try_clone_vec() {
         // let v: Vec<u8> = from_elem(1, 10);
@@ -313,4 +395,49 @@ mod tests {
     //     let v = try_vec![42_u8; 1000000000];
     //     assert_eq!(v.try_clone().unwrap(), v);
     // }
+
+    #[test]
+    fn oom() {
+        let mut vec: Vec<char> = Vec::new();
+        match FallibleVec::try_reserve(&mut vec, std::usize::MAX) {
+            Ok(_) => panic!("it should be OOM"),
+            _ => (),
+        }
+    }
+
+    #[test]
+    fn try_reserve() {
+        let mut vec: Vec<_> = vec![1];
+        let old_cap = vec.capacity();
+        let new_cap = old_cap + 1;
+        FallibleVec::try_reserve(&mut vec, new_cap).unwrap();
+        assert!(vec.capacity() >= new_cap);
+    }
+
+    #[test]
+    fn try_reserve_idempotent() {
+        let mut vec: Vec<_> = vec![1];
+        let old_cap = vec.capacity();
+        let new_cap = old_cap + 1;
+        FallibleVec::try_reserve(&mut vec, new_cap).unwrap();
+        let cap_after_reserve = vec.capacity();
+        FallibleVec::try_reserve(&mut vec, new_cap).unwrap();
+        assert_eq!(cap_after_reserve, vec.capacity());
+    }
+
+    #[test]
+    fn capacity_overflow() {
+        let mut vec: Vec<_> = vec![1];
+        match FallibleVec::try_reserve(&mut vec, std::usize::MAX) {
+            Ok(_) => panic!("capacity calculation should overflow"),
+            _ => (),
+        }
+    }
+
+    #[test]
+    fn extend_from_slice() {
+        let mut vec: Vec<u8> = b"foo".as_ref().into();
+        vec.try_extend_from_slice(b"bar").unwrap();
+        assert_eq!(vec, b"foobar".as_ref());
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/vcombey/fallible_collections/issues/1

Unstable features now require the `unstable` feature to be enabled.
Most functionality is preserved, with the exception of the btree module
and the TryClone trait.

A dependency on the hashbrown crate is added to use its CollectionAllocErr.
It will be used more extensively when support for types requiring fallible
allocation is added.

See https://github.com/vcombey/fallible_collections/issues/2.