### PR TITLE
Fallible only types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,5 @@ hashbrown = "0.7.1"
 [features]
 # Enable on nightly builds to allow use of unstable features
 unstable = []
+# Functionality based on std::io types
+std_io = []

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -14,6 +14,34 @@ pub trait FallibleBox<T> {
     where
         Self: Sized;
 }
+/// TryBox is a thin wrapper around alloc::boxed::Box to provide support for
+/// fallible allocation.
+///
+/// See the crate documentation for more.
+pub struct TryBox<T> {
+    inner: Box<T>,
+}
+
+impl<T> TryBox<T> {
+    pub fn try_new(t: T) -> Result<Self, TryReserveError> {
+        Ok(Self {
+            inner: Box::try_new(t)?,
+        })
+    }
+
+    pub fn into_raw(b: TryBox<T>) -> *mut T {
+        Box::into_raw(b.inner)
+    }
+
+    /// # Safety
+    ///
+    /// See std::boxed::from_raw
+    pub unsafe fn from_raw(raw: *mut T) -> Self {
+        Self {
+            inner: Box::from_raw(raw),
+        }
+    }
+}
 
 fn alloc(layout: Layout) -> Result<NonNull<u8>, TryReserveError> {
     #[cfg(feature = "unstable")] // requires allocator_api

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -43,6 +43,13 @@ impl<T> TryBox<T> {
     }
 }
 
+impl<T: TryClone> TryClone for TryBox<T> {
+    fn try_clone(&self) -> Result<Self, TryReserveError> {
+        let clone: T = (*self.inner).try_clone()?;
+        Self::try_new(clone)
+    }
+}
+
 fn alloc(layout: Layout) -> Result<NonNull<u8>, TryReserveError> {
     #[cfg(feature = "unstable")] // requires allocator_api
     {

--- a/src/hashmap.rs
+++ b/src/hashmap.rs
@@ -1,0 +1,41 @@
+//! Implement Fallible HashMap
+use crate::TryReserveError;
+use core::hash::Hash;
+
+#[derive(Default)]
+pub struct TryHashMap<K, V> {
+    #[cfg(feature = "unstable")]
+    inner: std::collections::HashMap<K, V>,
+    #[cfg(not(feature = "unstable"))]
+    inner: hashbrown::hash_map::HashMap<K, V>,
+}
+
+impl<K, V> TryHashMap<K, V>
+where
+    K: Eq + Hash,
+{
+    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    where
+        K: core::borrow::Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.inner.get(k)
+    }
+
+    pub fn insert(&mut self, k: K, v: V) -> Result<Option<V>, TryReserveError> {
+        self.reserve(if self.inner.capacity() == 0 { 4 } else { 1 })?;
+        Ok(self.inner.insert(k, v))
+    }
+
+    fn reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.inner.try_reserve(additional)
+    }
+}
+
+#[test]
+fn tryhashmap_oom() {
+    match TryHashMap::<char, char>::default().reserve(core::usize::MAX) {
+        Ok(_) => panic!("it should be OOM"),
+        _ => (),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub use vec::std_io::*;
 /// assert_eq!(vec.try_clone().unwrap(), vec)
 /// ```
 pub trait TryClone {
-    /// try clone method, (Self must be size because of Result
+    /// try clone method, (Self must be sized because of Result
     /// constraint)
     fn try_clone(&self) -> Result<Self, TryReserveError>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,25 @@
 //! in [RFC 2116](https://github.com/rust-lang/rfcs/blob/master/text/2116-alloc-me-maybe.md)
 //! This was used in the turbofish OS hobby project to mitigate the
 //! the lack of faillible allocation in rust.
+//!
+//! The `Try*` types in this module are thin wrappers around the stdlib types to add
+//! support for fallible allocation. The API differences from the stdlib types ensure
+//! that all operations which allocate return a `Result`. For the most part, this simply
+//! means adding a `Result` return value to functions which return nothing or a
+//! non-`Result` value. However, these types implement some traits whose API cannot
+//! communicate failure, but which do require allocation, so it is important that these
+//! wrapper types do not implement these traits.
+//!
+//! Specifically, these types must not implement any of the following traits:
+//! - Clone
+//! - Extend
+//! - From
+//! - FromIterator
+//!
+//! This list may not be exhaustive. Exercise caution when implementing
+//! any new traits to ensure they won't potentially allocate in a way that
+//! can't return a Result to indicate allocation failure.
+
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(feature = "unstable", feature(try_reserve))]
 #![cfg_attr(feature = "unstable", feature(specialization))]
@@ -14,6 +33,8 @@
 #![cfg_attr(feature = "unstable", feature(maybe_uninit_extra))]
 #![cfg_attr(feature = "unstable", feature(internal_uninit_const))]
 extern crate alloc;
+#[cfg(feature = "std_io")]
+extern crate std;
 
 pub mod boxed;
 pub use boxed::*;
@@ -26,14 +47,19 @@ pub mod arc;
 pub use arc::*;
 #[cfg(feature = "unstable")]
 pub mod btree;
+pub mod hashmap;
+pub use hashmap::*;
 #[macro_use]
 pub mod format;
 pub mod try_clone;
 
 #[cfg(feature = "unstable")]
-use alloc::collections::TryReserveError;
+pub use alloc::collections::TryReserveError;
 #[cfg(not(feature = "unstable"))]
-use hashbrown::CollectionAllocErr as TryReserveError;
+pub use hashbrown::CollectionAllocErr as TryReserveError;
+
+#[cfg(feature = "std_io")]
+pub use vec::std_io::*;
 
 /// trait for trying to clone an elem, return an error instead of
 /// panic if allocation failed

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -4,6 +4,7 @@ use crate::TryReserveError;
 #[cfg(not(feature = "unstable"))]
 use alloc::alloc::{alloc, realloc, Layout};
 use alloc::vec::Vec;
+use core::convert::TryInto as _;
 
 #[cfg(feature = "unstable")]
 #[macro_export]
@@ -142,6 +143,12 @@ impl<T> TryVec<T> {
     }
 }
 
+impl<T: TryClone> TryClone for TryVec<T> {
+    fn try_clone(&self) -> Result<Self, TryReserveError> {
+        self.as_slice().try_into()
+    }
+}
+
 impl<T: TryClone> TryVec<TryVec<T>> {
     pub fn concat(&self) -> Result<TryVec<T>, TryReserveError> {
         let size = self.iter().map(|v| v.inner.len()).sum();
@@ -180,7 +187,6 @@ impl<'a, T> IntoIterator for &'a TryVec<T> {
 #[cfg(feature = "std_io")]
 pub mod std_io {
     use super::*;
-    use core::convert::TryInto as _;
     use std::io::{self, Read, Take, Write};
 
     pub trait TryRead {
@@ -708,7 +714,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::convert::TryInto as _;
 
     #[test]
     #[cfg(feature = "unstable")]

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -733,6 +733,23 @@ mod tests {
         assert_eq!(v.try_clone().unwrap(), v);
     }
 
+    #[test]
+    fn try_clone_oom() {
+        let layout = Layout::new::<u8>();
+        let v =
+            unsafe { Vec::<u8>::from_raw_parts(alloc(layout), core::usize::MAX, core::usize::MAX) };
+        assert!(v.try_clone().is_err());
+    }
+
+    #[test]
+    fn tryvec_try_clone_oom() {
+        let layout = Layout::new::<u8>();
+        let inner =
+            unsafe { Vec::<u8>::from_raw_parts(alloc(layout), core::usize::MAX, core::usize::MAX) };
+        let tv = TryVec { inner };
+        assert!(tv.try_clone().is_err());
+    }
+
     // #[test]
     // fn try_out_of_mem() {
     //     let v = try_vec![42_u8; 1000000000];


### PR DESCRIPTION
This is based on https://github.com/vcombey/fallible_collections/pull/3, so you can ignore the first commit for now and just look at https://github.com/vcombey/fallible_collections/commit/7e62b06ec26420c9f40cbe847830e96bff379ff1. I'll rebase after https://github.com/vcombey/fallible_collections/pull/3 is merged, but I wanted to put this here since I've already completed the work.