### PR TITLE
[Fixed compilation error] Unique did not implement from<NonNull<_>>, …

### DIFF
--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -191,7 +191,7 @@ impl<K, V> BoxedNode<K, V> {
 
     unsafe fn from_ptr(ptr: NonNull<LeafNode<K, V>>) -> Self {
         BoxedNode {
-            ptr: Unique::from(ptr),
+            ptr: Unique::new_unchecked(ptr.as_ptr()),
         }
     }
 


### PR DESCRIPTION
…constructed it using Unique::new_unchecked() instead.
Compilation was broken when feature unstable was enabled.
This commit hopefully fixes the issue without breaking any of the invariants.
I haven't read the codebase though. 
However we're currently updating Turbofish to the current nightly rust, and we wanted to update the faillible_collections dependency to the 1.2.0 version, so we need this fix to pass.