### PR TITLE
Implement Default for TryVec<T> for all T

### DIFF
--- a/src/vec.rs
+++ b/src/vec.rs
@@ -64,9 +64,17 @@ pub trait FallibleVec<T> {
 /// fallible allocation.
 ///
 /// See the crate documentation for more.
-#[derive(Default, PartialEq)]
+#[derive(PartialEq)]
 pub struct TryVec<T> {
     inner: Vec<T>,
+}
+
+impl<T> Default for TryVec<T> {
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
 }
 
 impl<T: core::fmt::Debug> core::fmt::Debug for TryVec<T> {


### PR DESCRIPTION
[Per `Default` docs](https://doc.rust-lang.org/stable/std/default/trait.Default.html?search=#derivable) (emphasis mine):
>  This trait can be used with `#[derive]` **if all of the type's fields implement `Default`**. When `derive`d, it will use the default value for each field's type.

The default for `TryVec<T>` is an empty collection, so there's no need to require that `T` implement default. As with [stdlib `Vec`](https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#impl-Default), implementing this directly allows us to avoid this unnecessary bound.