### PR TITLE
Fix TryVec Debug formatting

### DIFF
--- a/src/vec.rs
+++ b/src/vec.rs
@@ -79,7 +79,7 @@ impl<T> Default for TryVec<T> {
 
 impl<T: core::fmt::Debug> core::fmt::Debug for TryVec<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{:?}", self.inner)
+        self.inner.fmt(f)
     }
 }
 


### PR DESCRIPTION
Using an explicit `"{:?}"` string prevents callers from passing down additional flags such as `"{:#?}"`