### PR TITLE
Annotate small functions with #[inline]

### DIFF
--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -23,12 +23,14 @@ pub struct TryBox<T> {
 }
 
 impl<T> TryBox<T> {
+    #[inline]
     pub fn try_new(t: T) -> Result<Self, TryReserveError> {
         Ok(Self {
             inner: Box::try_new(t)?,
         })
     }
 
+    #[inline(always)]
     pub fn into_raw(b: TryBox<T>) -> *mut T {
         Box::into_raw(b.inner)
     }
@@ -36,6 +38,7 @@ impl<T> TryBox<T> {
     /// # Safety
     ///
     /// See std::boxed::from_raw
+    #[inline(always)]
     pub unsafe fn from_raw(raw: *mut T) -> Self {
         Self {
             inner: Box::from_raw(raw),
@@ -91,6 +94,7 @@ impl<T> FallibleBox<T> for Box<T> {
 }
 
 impl<T: TryClone> TryClone for Box<T> {
+    #[inline]
     fn try_clone(&self) -> Result<Self, TryReserveError> {
         Self::try_new(Borrow::<T>::borrow(self).try_clone()?)
     }

--- a/src/btree/map.rs
+++ b/src/btree/map.rs
@@ -683,6 +683,7 @@ impl<K: Ord, V> BTreeMap<K, V> {
     /// assert_eq!(map.contains_key(&2), false);
     /// ```
 
+    #[inline]
     pub fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
     where
         K: Borrow<Q>,
@@ -1252,6 +1253,7 @@ impl<'a, K: 'a, V: 'a> IntoIterator for &'a BTreeMap<K, V> {
 impl<'a, K: 'a, V: 'a> Iterator for Iter<'a, K, V> {
     type Item = (&'a K, &'a V);
 
+    #[inline]
     fn next(&mut self) -> Option<(&'a K, &'a V)> {
         if self.length == 0 {
             None
@@ -1261,6 +1263,7 @@ impl<'a, K: 'a, V: 'a> Iterator for Iter<'a, K, V> {
         }
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.length, Some(self.length))
     }
@@ -1280,6 +1283,7 @@ impl<'a, K: 'a, V: 'a> DoubleEndedIterator for Iter<'a, K, V> {
 }
 
 impl<K, V> ExactSizeIterator for Iter<'_, K, V> {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.length
     }
@@ -1298,6 +1302,7 @@ impl<'a, K: 'a, V: 'a> IntoIterator for &'a mut BTreeMap<K, V> {
     type Item = (&'a K, &'a mut V);
     type IntoIter = IterMut<'a, K, V>;
 
+    #[inline(always)]
     fn into_iter(self) -> IterMut<'a, K, V> {
         self.iter_mut()
     }
@@ -1306,6 +1311,7 @@ impl<'a, K: 'a, V: 'a> IntoIterator for &'a mut BTreeMap<K, V> {
 impl<'a, K: 'a, V: 'a> Iterator for IterMut<'a, K, V> {
     type Item = (&'a K, &'a mut V);
 
+    #[inline]
     fn next(&mut self) -> Option<(&'a K, &'a mut V)> {
         if self.length == 0 {
             None
@@ -1315,6 +1321,7 @@ impl<'a, K: 'a, V: 'a> Iterator for IterMut<'a, K, V> {
         }
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.length, Some(self.length))
     }
@@ -1332,6 +1339,7 @@ impl<'a, K: 'a, V: 'a> DoubleEndedIterator for IterMut<'a, K, V> {
 }
 
 impl<K, V> ExactSizeIterator for IterMut<'_, K, V> {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.length
     }
@@ -1415,6 +1423,7 @@ impl<K, V> Iterator for IntoIter<K, V> {
         }
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.length, Some(self.length))
     }
@@ -1459,6 +1468,7 @@ impl<K, V> DoubleEndedIterator for IntoIter<K, V> {
 }
 
 impl<K, V> ExactSizeIterator for IntoIter<K, V> {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.length
     }
@@ -1469,22 +1479,26 @@ impl<K, V> FusedIterator for IntoIter<K, V> {}
 impl<'a, K, V> Iterator for Keys<'a, K, V> {
     type Item = &'a K;
 
+    #[inline]
     fn next(&mut self) -> Option<&'a K> {
         self.inner.next().map(|(k, _)| k)
     }
 
+    #[inline(always)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 }
 
 impl<'a, K, V> DoubleEndedIterator for Keys<'a, K, V> {
+    #[inline]
     fn next_back(&mut self) -> Option<&'a K> {
         self.inner.next_back().map(|(k, _)| k)
     }
 }
 
 impl<K, V> ExactSizeIterator for Keys<'_, K, V> {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -1493,6 +1507,7 @@ impl<K, V> ExactSizeIterator for Keys<'_, K, V> {
 impl<K, V> FusedIterator for Keys<'_, K, V> {}
 
 impl<K, V> Clone for Keys<'_, K, V> {
+    #[inline(always)]
     fn clone(&self) -> Self {
         Keys {
             inner: self.inner.clone(),
@@ -1503,22 +1518,26 @@ impl<K, V> Clone for Keys<'_, K, V> {
 impl<'a, K, V> Iterator for Values<'a, K, V> {
     type Item = &'a V;
 
+    #[inline]
     fn next(&mut self) -> Option<&'a V> {
         self.inner.next().map(|(_, v)| v)
     }
 
+    #[inline(always)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 }
 
 impl<'a, K, V> DoubleEndedIterator for Values<'a, K, V> {
+    #[inline]
     fn next_back(&mut self) -> Option<&'a V> {
         self.inner.next_back().map(|(_, v)| v)
     }
 }
 
 impl<K, V> ExactSizeIterator for Values<'_, K, V> {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -1527,6 +1546,7 @@ impl<K, V> ExactSizeIterator for Values<'_, K, V> {
 impl<K, V> FusedIterator for Values<'_, K, V> {}
 
 impl<K, V> Clone for Values<'_, K, V> {
+    #[inline(always)]
     fn clone(&self) -> Self {
         Values {
             inner: self.inner.clone(),
@@ -1537,6 +1557,7 @@ impl<K, V> Clone for Values<'_, K, V> {
 impl<'a, K, V> Iterator for Range<'a, K, V> {
     type Item = (&'a K, &'a V);
 
+    #[inline]
     fn next(&mut self) -> Option<(&'a K, &'a V)> {
         if self.front == self.back {
             None
@@ -1549,22 +1570,26 @@ impl<'a, K, V> Iterator for Range<'a, K, V> {
 impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
     type Item = &'a mut V;
 
+    #[inline]
     fn next(&mut self) -> Option<&'a mut V> {
         self.inner.next().map(|(_, v)| v)
     }
 
+    #[inline(always)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 }
 
 impl<'a, K, V> DoubleEndedIterator for ValuesMut<'a, K, V> {
+    #[inline]
     fn next_back(&mut self) -> Option<&'a mut V> {
         self.inner.next_back().map(|(_, v)| v)
     }
 }
 
 impl<K, V> ExactSizeIterator for ValuesMut<'_, K, V> {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -1605,6 +1630,7 @@ impl<'a, K, V> Range<'a, K, V> {
 }
 
 impl<'a, K, V> DoubleEndedIterator for Range<'a, K, V> {
+    #[inline]
     fn next_back(&mut self) -> Option<(&'a K, &'a V)> {
         if self.front == self.back {
             None
@@ -1649,6 +1675,7 @@ impl<'a, K, V> Range<'a, K, V> {
 impl<K, V> FusedIterator for Range<'_, K, V> {}
 
 impl<K, V> Clone for Range<'_, K, V> {
+    #[inline]
     fn clone(&self) -> Self {
         Range {
             front: self.front,
@@ -1660,6 +1687,7 @@ impl<K, V> Clone for Range<'_, K, V> {
 impl<'a, K, V> Iterator for RangeMut<'a, K, V> {
     type Item = (&'a K, &'a mut V);
 
+    #[inline]
     fn next(&mut self) -> Option<(&'a K, &'a mut V)> {
         if self.front == self.back {
             None
@@ -1706,6 +1734,7 @@ impl<'a, K, V> RangeMut<'a, K, V> {
 }
 
 impl<'a, K, V> DoubleEndedIterator for RangeMut<'a, K, V> {
+    #[inline]
     fn next_back(&mut self) -> Option<(&'a K, &'a mut V)> {
         if self.front == self.back {
             None
@@ -1754,6 +1783,7 @@ impl<'a, K, V> RangeMut<'a, K, V> {
 }
 
 impl<K: Ord, V> FromIterator<(K, V)> for BTreeMap<K, V> {
+    #[inline]
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> BTreeMap<K, V> {
         let mut map = BTreeMap::new();
         map.extend(iter);
@@ -1771,6 +1801,7 @@ impl<K: Ord, V> Extend<(K, V)> for BTreeMap<K, V> {
 }
 
 impl<'a, K: Ord + Copy, V: Copy> Extend<(&'a K, &'a V)> for BTreeMap<K, V> {
+    #[inline]
     fn extend<I: IntoIterator<Item = (&'a K, &'a V)>>(&mut self, iter: I) {
         self.extend(iter.into_iter().map(|(&key, &value)| (key, value)));
     }
@@ -1786,6 +1817,7 @@ impl<K: Hash, V: Hash> Hash for BTreeMap<K, V> {
 
 impl<K: Ord, V> Default for BTreeMap<K, V> {
     /// Creates an empty `BTreeMap<K, V>`.
+    #[inline(always)]
     fn default() -> BTreeMap<K, V> {
         BTreeMap::new()
     }
@@ -2057,6 +2089,7 @@ impl<K, V> BTreeMap<K, V> {
     /// assert_eq!(keys, [1, 2]);
     /// ```
 
+    #[inline(always)]
     pub fn keys<'a>(&'a self) -> Keys<'a, K, V> {
         Keys { inner: self.iter() }
     }
@@ -2078,6 +2111,7 @@ impl<K, V> BTreeMap<K, V> {
     /// assert_eq!(values, ["hello", "goodbye"]);
     /// ```
 
+    #[inline(always)]
     pub fn values<'a>(&'a self) -> Values<'a, K, V> {
         Values { inner: self.iter() }
     }
@@ -2104,6 +2138,7 @@ impl<K, V> BTreeMap<K, V> {
     ///                     String::from("goodbye!")]);
     /// ```
 
+    #[inline(always)]
     pub fn values_mut(&mut self) -> ValuesMut<'_, K, V> {
         ValuesMut {
             inner: self.iter_mut(),
@@ -2125,6 +2160,7 @@ impl<K, V> BTreeMap<K, V> {
     /// assert_eq!(a.len(), 1);
     /// ```
 
+    #[inline(always)]
     pub fn len(&self) -> usize {
         self.length
     }
@@ -2144,6 +2180,7 @@ impl<K, V> BTreeMap<K, V> {
     /// assert!(!a.is_empty());
     /// ```
 
+    #[inline(always)]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -2208,6 +2245,7 @@ impl<'a, K: Ord, V> Entry<'a, K, V> {
     /// assert_eq!(map.entry("poneyland").key(), &"poneyland");
     /// ```
 
+    #[inline]
     pub fn key(&self) -> &K {
         match *self {
             Occupied(ref entry) => entry.key(),
@@ -2287,6 +2325,7 @@ impl<'a, K: Ord, V> VacantEntry<'a, K, V> {
     /// assert_eq!(map.entry("poneyland").key(), &"poneyland");
     /// ```
 
+    #[inline(always)]
     pub fn key(&self) -> &K {
         &self.key
     }
@@ -2305,7 +2344,7 @@ impl<'a, K: Ord, V> VacantEntry<'a, K, V> {
     ///     v.into_key();
     /// }
     /// ```
-
+    #[inline(always)]
     pub fn into_key(self) -> K {
         self.key
     }
@@ -2381,6 +2420,7 @@ impl<'a, K: Ord, V> OccupiedEntry<'a, K, V> {
     /// assert_eq!(map.entry("poneyland").key(), &"poneyland");
     /// ```
 
+    #[inline]
     pub fn key(&self) -> &K {
         self.handle.reborrow().into_kv().0
     }
@@ -2405,6 +2445,7 @@ impl<'a, K: Ord, V> OccupiedEntry<'a, K, V> {
     /// // println!("{}", map["poneyland"]);
     /// ```
 
+    #[inline]
     pub fn remove_entry(self) -> (K, V) {
         self.remove_kv()
     }
@@ -2425,6 +2466,7 @@ impl<'a, K: Ord, V> OccupiedEntry<'a, K, V> {
     /// }
     /// ```
 
+    #[inline]
     pub fn get(&self) -> &V {
         self.handle.reborrow().into_kv().1
     }
@@ -2455,7 +2497,7 @@ impl<'a, K: Ord, V> OccupiedEntry<'a, K, V> {
     /// }
     /// assert_eq!(map["poneyland"], 24);
     /// ```
-
+    #[inline]
     pub fn get_mut(&mut self) -> &mut V {
         self.handle.kv_mut().1
     }
@@ -2481,7 +2523,7 @@ impl<'a, K: Ord, V> OccupiedEntry<'a, K, V> {
     /// }
     /// assert_eq!(map["poneyland"], 22);
     /// ```
-
+    #[inline]
     pub fn into_mut(self) -> &'a mut V {
         self.handle.into_kv_mut().1
     }
@@ -2503,7 +2545,7 @@ impl<'a, K: Ord, V> OccupiedEntry<'a, K, V> {
     /// }
     /// assert_eq!(map["poneyland"], 15);
     /// ```
-
+    #[inline]
     pub fn insert(&mut self, value: V) -> V {
         mem::replace(self.get_mut(), value)
     }
@@ -2525,7 +2567,7 @@ impl<'a, K: Ord, V> OccupiedEntry<'a, K, V> {
     /// // If we try to get "poneyland"'s value, it'll panic:
     /// // println!("{}", map["poneyland"]);
     /// ```
-
+    #[inline]
     pub fn remove(self) -> V {
         self.remove_kv().1
     }

--- a/src/btree/set.rs
+++ b/src/btree/set.rs
@@ -253,6 +253,7 @@ impl<T: Ord> BTreeSet<T> {
     /// let mut set: BTreeSet<i32> = BTreeSet::new();
     /// ```
 
+    #[inline]
     pub fn new() -> BTreeSet<T> {
         BTreeSet {
             map: BTreeMap::new(),
@@ -282,6 +283,7 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(Some(&5), set.range(4..).next());
     /// ```
 
+    #[inline]
     pub fn range<K: ?Sized, R>(&self, range: R) -> Range<'_, T>
     where
         K: Ord,
@@ -357,6 +359,7 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(sym_diff, [1, 3]);
     /// ```
 
+    #[inline]
     pub fn symmetric_difference<'a>(
         &'a self,
         other: &'a BTreeSet<T>,
@@ -434,6 +437,7 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(union, [1, 2]);
     /// ```
 
+    #[inline]
     pub fn union<'a>(&'a self, other: &'a BTreeSet<T>) -> Union<'a, T> {
         Union {
             a: self.iter().peekable(),
@@ -454,6 +458,7 @@ impl<T: Ord> BTreeSet<T> {
     /// assert!(v.is_empty());
     /// ```
 
+    #[inline(always)]
     pub fn clear(&mut self) {
         self.map.clear()
     }
@@ -474,6 +479,7 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(set.contains(&4), false);
     /// ```
 
+    #[inline(always)]
     pub fn contains<Q: ?Sized>(&self, value: &Q) -> bool
     where
         T: Borrow<Q>,
@@ -498,6 +504,7 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(set.get(&4), None);
     /// ```
 
+    #[inline(always)]
     pub fn get<Q: ?Sized>(&self, value: &Q) -> Option<&T>
     where
         T: Borrow<Q>,
@@ -524,6 +531,7 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(a.is_disjoint(&b), false);
     /// ```
 
+    #[inline]
     pub fn is_disjoint(&self, other: &BTreeSet<T>) -> bool {
         self.intersection(other).next().is_none()
     }
@@ -608,6 +616,7 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(set.is_superset(&sub), true);
     /// ```
 
+    #[inline(always)]
     pub fn is_superset(&self, other: &BTreeSet<T>) -> bool {
         other.is_subset(self)
     }
@@ -633,6 +642,7 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(set.len(), 1);
     /// ```
 
+    #[inline]
     pub fn try_insert(&mut self, value: T) -> Result<bool, TryReserveError> {
         Ok(self.map.try_insert(value, ())?.is_none())
     }
@@ -653,6 +663,7 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(set.get(&[][..]).unwrap().capacity(), 10);
     /// ```
 
+    #[inline]
     pub fn replace(&mut self, value: T) -> Result<Option<T>, TryReserveError> {
         Ok(Recover::replace(&mut self.map, value)?)
     }
@@ -676,6 +687,7 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(set.remove(&2), false);
     /// ```
 
+    #[inline(always)]
     pub fn remove<Q: ?Sized>(&mut self, value: &Q) -> bool
     where
         T: Borrow<Q>,
@@ -700,6 +712,7 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(set.take(&2), None);
     /// ```
 
+    #[inline(always)]
     pub fn take<Q: ?Sized>(&mut self, value: &Q) -> Option<T>
     where
         T: Borrow<Q>,
@@ -737,6 +750,7 @@ impl<T: Ord> BTreeSet<T> {
     /// assert!(a.contains(&5));
     /// ```
 
+    #[inline(always)]
     pub fn append(&mut self, other: &mut Self) {
         self.map.append(&mut other.map);
     }
@@ -771,6 +785,7 @@ impl<T: Ord> BTreeSet<T> {
     /// assert!(b.contains(&41));
     /// ```
 
+    #[inline]
     pub fn try_split_off<Q: ?Sized + Ord>(&mut self, key: &Q) -> Result<Self, TryReserveError>
     where
         T: Borrow<Q>,
@@ -810,6 +825,7 @@ impl<T> BTreeSet<T> {
     /// assert_eq!(set_iter.next(), None);
     /// ```
 
+    #[inline(always)]
     pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             iter: self.map.keys(),
@@ -829,6 +845,7 @@ impl<T> BTreeSet<T> {
     /// assert_eq!(v.len(), 1);
     /// ```
 
+    #[inline(always)]
     pub fn len(&self) -> usize {
         self.map.len()
     }
@@ -846,12 +863,14 @@ impl<T> BTreeSet<T> {
     /// assert!(!v.is_empty());
     /// ```
 
+    #[inline(always)]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 }
 
 impl<T: Ord> FromIterator<T> for BTreeSet<T> {
+    #[inline]
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> BTreeSet<T> {
         let mut set = BTreeSet::new();
         set.extend(iter);
@@ -875,6 +894,7 @@ impl<T> IntoIterator for BTreeSet<T> {
     /// let v: Vec<_> = set.into_iter().collect();
     /// assert_eq!(v, [1, 2, 3, 4]);
     /// ```
+    #[inline(always)]
     fn into_iter(self) -> IntoIter<T> {
         IntoIter {
             iter: self.map.into_iter(),
@@ -886,6 +906,7 @@ impl<'a, T> IntoIterator for &'a BTreeSet<T> {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;
 
+    #[inline(always)]
     fn into_iter(self) -> Iter<'a, T> {
         self.iter()
     }
@@ -901,6 +922,7 @@ impl<T: Ord> Extend<T> for BTreeSet<T> {
 }
 
 impl<'a, T: 'a + Ord + Copy> Extend<&'a T> for BTreeSet<T> {
+    #[inline]
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
         self.extend(iter.into_iter().cloned());
     }
@@ -908,6 +930,7 @@ impl<'a, T: 'a + Ord + Copy> Extend<&'a T> for BTreeSet<T> {
 
 impl<T: Ord> Default for BTreeSet<T> {
     /// Makes an empty `BTreeSet<T>` with a reasonable choice of B.
+    #[inline(always)]
     fn default() -> BTreeSet<T> {
         BTreeSet::new()
     }
@@ -1008,6 +1031,7 @@ impl<T: Debug> Debug for BTreeSet<T> {
 }
 
 impl<T> Clone for Iter<'_, T> {
+    #[inline(always)]
     fn clone(&self) -> Self {
         Iter {
             iter: self.iter.clone(),
@@ -1018,21 +1042,26 @@ impl<T> Clone for Iter<'_, T> {
 impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
 
+    #[inline(always)]
     fn next(&mut self) -> Option<&'a T> {
         self.iter.next()
     }
+
+    #[inline(always)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
 }
 
 impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
+    #[inline(always)]
     fn next_back(&mut self) -> Option<&'a T> {
         self.iter.next_back()
     }
 }
 
 impl<T> ExactSizeIterator for Iter<'_, T> {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.iter.len()
     }
@@ -1043,21 +1072,26 @@ impl<T> FusedIterator for Iter<'_, T> {}
 impl<T> Iterator for IntoIter<T> {
     type Item = T;
 
+    #[inline]
     fn next(&mut self) -> Option<T> {
         self.iter.next().map(|(k, _)| k)
     }
+
+    #[inline(always)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
 }
 
 impl<T> DoubleEndedIterator for IntoIter<T> {
+    #[inline]
     fn next_back(&mut self) -> Option<T> {
         self.iter.next_back().map(|(k, _)| k)
     }
 }
 
 impl<T> ExactSizeIterator for IntoIter<T> {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.iter.len()
     }
@@ -1066,6 +1100,7 @@ impl<T> ExactSizeIterator for IntoIter<T> {
 impl<T> FusedIterator for IntoIter<T> {}
 
 impl<T> Clone for Range<'_, T> {
+    #[inline(always)]
     fn clone(&self) -> Self {
         Range {
             iter: self.iter.clone(),
@@ -1076,12 +1111,14 @@ impl<T> Clone for Range<'_, T> {
 impl<'a, T> Iterator for Range<'a, T> {
     type Item = &'a T;
 
+    #[inline]
     fn next(&mut self) -> Option<&'a T> {
         self.iter.next().map(|(k, _)| k)
     }
 }
 
 impl<'a, T> DoubleEndedIterator for Range<'a, T> {
+    #[inline]
     fn next_back(&mut self) -> Option<&'a T> {
         self.iter.next_back().map(|(k, _)| k)
     }
@@ -1201,6 +1238,7 @@ impl<'a, T: Ord> Iterator for SymmetricDifference<'a, T> {
         }
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (0, Some(self.a.len() + self.b.len()))
     }
@@ -1262,6 +1300,7 @@ impl<'a, T: Ord> Iterator for Intersection<'a, T> {
         }
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let min_len = match &self.inner {
             IntersectionInner::Stitch { small_iter, .. } => small_iter.len(),
@@ -1274,6 +1313,7 @@ impl<'a, T: Ord> Iterator for Intersection<'a, T> {
 impl<T: Ord> FusedIterator for Intersection<'_, T> {}
 
 impl<T> Clone for Union<'_, T> {
+    #[inline]
     fn clone(&self) -> Self {
         Union {
             a: self.a.clone(),

--- a/src/hashmap.rs
+++ b/src/hashmap.rs
@@ -16,6 +16,7 @@ impl<K, V> TryHashMap<K, V>
 where
     K: Eq + Hash,
 {
+    #[inline]
     pub fn with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
         let mut map = Self {
             inner: HashMap::new(),
@@ -24,6 +25,7 @@ where
         Ok(map)
     }
 
+    #[inline(always)]
     pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
@@ -32,19 +34,23 @@ where
         self.inner.get(k)
     }
 
+    #[inline]
     pub fn insert(&mut self, k: K, v: V) -> Result<Option<V>, TryReserveError> {
         self.reserve(if self.inner.capacity() == 0 { 4 } else { 1 })?;
         Ok(self.inner.insert(k, v))
     }
 
+    #[inline(always)]
     pub fn iter(&self) -> hashbrown::hash_map::Iter<'_, K, V> {
         self.inner.iter()
     }
 
+    #[inline(always)]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
+    #[inline(always)]
     pub fn remove<Q: ?Sized>(&mut self, k: &Q) -> Option<V>
     where
         K: Borrow<Q>,
@@ -53,6 +59,7 @@ where
         self.inner.remove(k)
     }
 
+    #[inline(always)]
     fn reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.inner.try_reserve(additional)
     }
@@ -62,6 +69,7 @@ impl<K, V> IntoIterator for TryHashMap<K, V> {
     type Item = (K, V);
     type IntoIter = hashbrown::hash_map::IntoIter<K, V>;
 
+    #[inline(always)]
     fn into_iter(self) -> Self::IntoIter {
         self.inner.into_iter()
     }

--- a/src/try_clone.rs
+++ b/src/try_clone.rs
@@ -21,6 +21,7 @@ macro_rules! impl_try_clone {
 impl_try_clone!(u8, u16, u32, u64, i8, i16, i32, i64, usize, isize, bool);
 
 impl<T: TryClone> TryClone for Option<T> {
+    #[inline]
     fn try_clone(&self) -> Result<Self, TryReserveError> {
         Ok(match self {
             Some(t) => Some(t.try_clone()?),

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -70,6 +70,7 @@ pub struct TryVec<T> {
 }
 
 impl<T> Default for TryVec<T> {
+    #[inline(always)]
     fn default() -> Self {
         Self {
             inner: Default::default(),
@@ -78,34 +79,41 @@ impl<T> Default for TryVec<T> {
 }
 
 impl<T: core::fmt::Debug> core::fmt::Debug for TryVec<T> {
+    #[inline]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.inner.fmt(f)
     }
 }
 
 impl<T> TryVec<T> {
+    #[inline(always)]
     pub fn new() -> Self {
         Self { inner: Vec::new() }
     }
 
+    #[inline]
     pub fn with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
         Ok(Self {
             inner: FallibleVec::try_with_capacity(capacity)?,
         })
     }
 
+    #[inline(always)]
     pub fn append(&mut self, other: &mut Self) -> Result<(), TryReserveError> {
         FallibleVec::try_append(&mut self.inner, &mut other.inner)
     }
 
+    #[inline(always)]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         self
     }
 
+    #[inline(always)]
     pub fn as_slice(&self) -> &[T] {
         self
     }
 
+    #[inline(always)]
     pub fn clear(&mut self) {
         self.inner.clear()
     }
@@ -115,34 +123,41 @@ impl<T> TryVec<T> {
         self.inner
     }
 
+    #[inline(always)]
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 
+    #[inline(always)]
     pub fn iter_mut(&mut self) -> IterMut<T> {
         IterMut {
             inner: self.inner.iter_mut(),
         }
     }
 
+    #[inline(always)]
     pub fn iter(&self) -> Iter<T> {
         Iter {
             inner: self.inner.iter(),
         }
     }
 
+    #[inline(always)]
     pub fn pop(&mut self) -> Option<T> {
         self.inner.pop()
     }
 
+    #[inline(always)]
     pub fn push(&mut self, value: T) -> Result<(), TryReserveError> {
         FallibleVec::try_push(&mut self.inner, value)
     }
 
+    #[inline(always)]
     pub fn reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         FallibleVec::try_reserve(&mut self.inner, additional)
     }
 
+    #[inline(always)]
     pub fn resize_with<F>(&mut self, new_len: usize, f: F) -> Result<(), TryReserveError>
     where
         F: FnMut() -> T,
@@ -152,6 +167,7 @@ impl<T> TryVec<T> {
 }
 
 impl<T: TryClone> TryClone for TryVec<T> {
+    #[inline]
     fn try_clone(&self) -> Result<Self, TryReserveError> {
         self.as_slice().try_into()
     }
@@ -169,6 +185,7 @@ impl<T: TryClone> TryVec<TryVec<T>> {
 }
 
 impl<T: TryClone> TryVec<T> {
+    #[inline(always)]
     pub fn extend_from_slice(&mut self, other: &[T]) -> Result<(), TryReserveError> {
         self.inner.try_extend_from_slice_no_copy(other)
     }
@@ -178,6 +195,7 @@ impl<T> IntoIterator for TryVec<T> {
     type Item = T;
     type IntoIter = alloc::vec::IntoIter<T>;
 
+    #[inline(always)]
     fn into_iter(self) -> Self::IntoIter {
         self.inner.into_iter()
     }
@@ -187,6 +205,7 @@ impl<'a, T> IntoIterator for &'a TryVec<T> {
     type Item = &'a T;
     type IntoIter = alloc::slice::Iter<'a, T>;
 
+    #[inline(always)]
     fn into_iter(self) -> Self::IntoIter {
         self.inner.iter()
     }
@@ -200,6 +219,7 @@ pub mod std_io {
     pub trait TryRead {
         fn try_read_to_end(&mut self, buf: &mut TryVec<u8>) -> io::Result<usize>;
 
+        #[inline]
         fn read_into_try_vec(&mut self) -> io::Result<TryVec<u8>> {
             let mut buf = TryVec::new();
             self.try_read_to_end(&mut buf)?;
@@ -220,6 +240,7 @@ pub mod std_io {
         /// to read would have succeeded. In general, it is assumed that the callers
         /// have accurate knowledge of the number of bytes of interest and have created
         /// `src` accordingly.
+        #[inline]
         fn try_read_to_end(&mut self, buf: &mut TryVec<u8>) -> io::Result<usize> {
             try_read_up_to(self, self.limit(), buf)
         }
@@ -249,6 +270,7 @@ pub mod std_io {
             Ok(buf.len())
         }
 
+        #[inline(always)]
         fn flush(&mut self) -> io::Result<()> {
             Ok(())
         }
@@ -302,30 +324,35 @@ pub mod std_io {
 }
 
 impl<T: PartialEq> PartialEq<Vec<T>> for TryVec<T> {
+    #[inline(always)]
     fn eq(&self, other: &Vec<T>) -> bool {
         self.inner.eq(other)
     }
 }
 
 impl<'a, T: PartialEq> PartialEq<&'a [T]> for TryVec<T> {
+    #[inline(always)]
     fn eq(&self, other: &&[T]) -> bool {
         self.inner.eq(other)
     }
 }
 
 impl PartialEq<&str> for TryVec<u8> {
+    #[inline]
     fn eq(&self, other: &&str) -> bool {
         self.as_slice() == other.as_bytes()
     }
 }
 
 impl core::convert::AsRef<[u8]> for TryVec<u8> {
+    #[inline(always)]
     fn as_ref(&self) -> &[u8] {
         self.inner.as_ref()
     }
 }
 
 impl<T> core::convert::From<Vec<T>> for TryVec<T> {
+    #[inline(always)]
     fn from(value: Vec<T>) -> Self {
         Self { inner: value }
     }
@@ -334,6 +361,7 @@ impl<T> core::convert::From<Vec<T>> for TryVec<T> {
 impl<T: TryClone> core::convert::TryFrom<&[T]> for TryVec<T> {
     type Error = TryReserveError;
 
+    #[inline]
     fn try_from(value: &[T]) -> Result<Self, Self::Error> {
         let mut v = Self::new();
         v.inner.try_extend_from_slice_no_copy(value)?;
@@ -344,6 +372,7 @@ impl<T: TryClone> core::convert::TryFrom<&[T]> for TryVec<T> {
 impl core::convert::TryFrom<&str> for TryVec<u8> {
     type Error = TryReserveError;
 
+    #[inline]
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         let mut v = Self::new();
         v.extend_from_slice(value.as_bytes())?;
@@ -354,6 +383,7 @@ impl core::convert::TryFrom<&str> for TryVec<u8> {
 impl<T> core::ops::Deref for TryVec<T> {
     type Target = [T];
 
+    #[inline(always)]
     fn deref(&self) -> &[T] {
         self.inner.deref()
     }
@@ -372,10 +402,12 @@ pub struct Iter<'a, T> {
 impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
 
+    #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 
+    #[inline(always)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
@@ -388,10 +420,12 @@ pub struct IterMut<'a, T> {
 impl<'a, T> Iterator for IterMut<'a, T> {
     type Item = &'a mut T;
 
+    #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 
+    #[inline(always)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
@@ -462,6 +496,8 @@ fn vec_try_extend<T>(v: &mut Vec<T>, new_cap: usize) -> Result<(), TryReserveErr
 }
 
 impl<T> FallibleVec<T> for Vec<T> {
+
+    #[inline(always)]
     fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         #[cfg(feature = "unstable")]
         {
@@ -473,16 +509,22 @@ impl<T> FallibleVec<T> for Vec<T> {
             vec_try_reserve(self, additional)
         }
     }
+
+    #[inline]
     fn try_push(&mut self, elem: T) -> Result<(), TryReserveError> {
         FallibleVec::try_reserve(self, 1)?;
         Ok(self.push(elem))
     }
+
+    #[inline]
     fn try_push_give_back(&mut self, elem: T) -> Result<(), (T, TryReserveError)> {
         if let Err(e) = FallibleVec::try_reserve(self, 1) {
             return Err((elem, e));
         }
         Ok(self.push(elem))
     }
+
+    #[inline]
     fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError>
     where
         Self: core::marker::Sized,
@@ -492,12 +534,14 @@ impl<T> FallibleVec<T> for Vec<T> {
         Ok(n)
     }
 
+    #[inline]
     fn try_insert(&mut self, index: usize, element: T) -> Result<(), (T, TryReserveError)> {
         if let Err(e) = FallibleVec::try_reserve(self, 1) {
             return Err((element, e));
         }
         Ok(self.insert(index, element))
     }
+    #[inline]
     fn try_append(&mut self, other: &mut Self) -> Result<(), TryReserveError> {
         FallibleVec::try_reserve(self, other.len())?;
         Ok(self.append(other))
@@ -534,6 +578,7 @@ impl<T> FallibleVec<T> for Vec<T> {
             Ok(self.truncate(new_len))
         }
     }
+    #[inline]
     fn try_extend_from_slice(&mut self, other: &[T]) -> Result<(), TryReserveError>
     where
         T: Clone,
@@ -567,9 +612,11 @@ trait ExtendWith<T> {
 
 struct TryExtendElement<T: TryClone>(T);
 impl<T: TryClone> ExtendWith<T> for TryExtendElement<T> {
+    #[inline(always)]
     fn next(&mut self) -> Result<T, TryReserveError> {
         self.0.try_clone()
     }
+    #[inline(always)]
     fn last(self) -> T {
         self.0
     }
@@ -679,6 +726,7 @@ impl SpecFromElem for u8 {
 }
 
 impl<T: TryClone> TryClone for Vec<T> {
+    #[inline]
     fn try_clone(&self) -> Result<Self, TryReserveError>
     where
         Self: core::marker::Sized,
@@ -714,6 +762,7 @@ impl<I, T> TryCollect<I> for T
 where
     T: IntoIterator<Item = I>,
 {
+    #[inline(always)]
     fn try_collect<C: TryFromIterator<I>>(self) -> Result<C, TryReserveError> {
         C::try_from_iterator(self)
     }


### PR DESCRIPTION
`#[inline]` annotations help inlining methods across crates, even without LTO.

I've also put `#[inline(always)]` on functions that only forward their call to another function, since that is a pure win, even from code size perspective.