### PR TITLE
Avoid future conflict with libstd's try_ methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ use fallible_collections::FallibleBox;
 
 fn main() {
 	// this crate an Ordinary box but return an error on allocation failure
-	let mut a = Box::try_new(5).unwrap();
+	let mut a = <Box<_> as FallibleBox<_>>::try_new(5).unwrap();
 	let mut b = Box::new(5);
 
 	assert_eq!(a, b);

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -18,11 +18,13 @@ pub trait FallibleArc<T> {
     where
         Self: Sized;
 }
+
+#[allow(deprecated)]
 impl<T> FallibleArc<T> for Arc<T> {
     fn try_new(t: T) -> Result<Self, TryReserveError> {
         // doesn't work as the inner variable of arc are also stocked in the box
 
-        let b = Box::try_new(t)?;
+        let b = <Box<T> as FallibleBox<T>>::try_new(t)?;
         Ok(Arc::from(b))
     }
 }

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -25,7 +25,7 @@ pub struct TryBox<T> {
 impl<T> TryBox<T> {
     pub fn try_new(t: T) -> Result<Self, TryReserveError> {
         Ok(Self {
-            inner: Box::try_new(t)?,
+            inner: <Box<T> as FallibleBox<T>>::try_new(t)?,
         })
     }
 
@@ -92,7 +92,7 @@ impl<T> FallibleBox<T> for Box<T> {
 
 impl<T: TryClone> TryClone for Box<T> {
     fn try_clone(&self) -> Result<Self, TryReserveError> {
-        Self::try_new(Borrow::<T>::borrow(self).try_clone()?)
+        <Self as FallibleBox<T>>::try_new(Borrow::<T>::borrow(self).try_clone()?)
     }
 }
 
@@ -101,7 +101,7 @@ mod tests {
     use super::*;
     #[test]
     fn boxed() {
-        let mut v = Box::try_new(5).unwrap();
+        let mut v = <Box<_> as FallibleBox<_>>::try_new(5).unwrap();
         assert_eq!(*v, 5);
         *v = 3;
         assert_eq!(*v, 3);
@@ -115,7 +115,7 @@ mod tests {
 
     #[test]
     fn trybox_zst() {
-        let b = Box::try_new(()).expect("ok");
+        let b = <Box<_> as FallibleBox<_>>::try_new(()).expect("ok");
         assert_eq!(b, Box::new(()));
     }
 }

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -228,7 +228,7 @@ impl<K, V> Root<K, V> {
 
     pub fn new_leaf() -> Result<Self, TryReserveError> {
         Ok(Root {
-            node: BoxedNode::from_leaf(Box::try_new(unsafe { LeafNode::new() })?),
+            node: BoxedNode::from_leaf(<Box<_> as FallibleBox<_>>::try_new(unsafe { LeafNode::new() })?),
             height: 0,
         })
     }
@@ -266,7 +266,7 @@ impl<K, V> Root<K, V> {
         &mut self,
     ) -> Result<NodeRef<marker::Mut<'_>, K, V, marker::Internal>, TryReserveError> {
         debug_assert!(!self.is_shared_root());
-        let mut new_node = Box::try_new(unsafe { InternalNode::new() })?;
+        let mut new_node = <Box<_> as FallibleBox<_>>::try_new(unsafe { InternalNode::new() })?;
         new_node.edges[0].write(unsafe { BoxedNode::from_ptr(self.node.as_ptr()) });
 
         self.node = BoxedNode::from_internal(new_node);
@@ -1193,7 +1193,7 @@ impl<'a, K, V> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Leaf>, marker::KV> 
     > {
         debug_assert!(!self.node.is_shared_root());
         unsafe {
-            let mut new_node = Box::try_new(LeafNode::new())?;
+            let mut new_node = <Box<_> as FallibleBox<_>>::try_new(LeafNode::new())?;
 
             let k = ptr::read(self.node.keys().get_unchecked(self.idx));
             let v = ptr::read(self.node.vals().get_unchecked(self.idx));
@@ -1265,7 +1265,7 @@ impl<'a, K, V> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::
         TryReserveError,
     > {
         unsafe {
-            let mut new_node = Box::try_new(InternalNode::new())?;
+            let mut new_node = <Box<_> as FallibleBox<_>>::try_new(InternalNode::new())?;
 
             let k = ptr::read(self.node.keys().get_unchecked(self.idx));
             let v = ptr::read(self.node.vals().get_unchecked(self.idx));

--- a/src/format.rs
+++ b/src/format.rs
@@ -3,7 +3,6 @@ use super::FallibleVec;
 use crate::TryReserveError;
 use alloc::fmt::{Arguments, Write};
 use alloc::string::String;
-use alloc::vec::Vec;
 
 /// Take a max capacity a try allocating a string with it.
 ///
@@ -14,7 +13,7 @@ use alloc::vec::Vec;
 /// capacity, no error is return and an allocation can occurs which
 /// can lead to a panic
 pub fn try_format(max_capacity: usize, args: Arguments<'_>) -> Result<String, TryReserveError> {
-    let v = Vec::try_with_capacity(max_capacity)?;
+    let v = FallibleVec::try_with_capacity(max_capacity)?;
     let mut s = String::from_utf8(v).expect("wtf an empty vec should be valid utf8");
     s.write_fmt(args)
         .expect("a formatting trait implementation returned an error");

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -14,7 +14,7 @@ pub trait FallibleRc<T> {
 
 impl<T> FallibleRc<T> for Rc<T> {
     fn try_new(t: T) -> Result<Self, TryReserveError> {
-        let b = Box::try_new(t)?;
+        let b = <Box<T> as FallibleBox<T>>::try_new(t)?;
         Ok(Rc::from(b))
     }
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -670,7 +670,7 @@ impl SpecFromElem for u8 {
     #[inline]
     fn try_from_elem(elem: u8, n: usize) -> Result<Vec<u8>, TryReserveError> {
         unsafe {
-            let mut v = Vec::try_with_capacity(n)?;
+            let mut v = FallibleVec::try_with_capacity(n)?;
             core::ptr::write_bytes(v.as_mut_ptr(), elem, n);
             v.set_len(n);
             Ok(v)


### PR DESCRIPTION
libstd is adding `try_new`. This changes syntax to explicit use of `FallibleBox` in order to avoid causing problems for libstd like premature custom try_from crates did.

