### PR TITLE
Update for Rust 1.57

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,8 @@ hashbrown = "0.11.2"
 # Enable on nightly builds to allow use of unstable features
 unstable = []
 # Functionality based on std::io types
-std_io = []
+std_io = ["std"]
+# Allow use of std
+std = []
+# Use fallible functions added in Rust 1.57
+rust_1_57 = []

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -71,6 +71,7 @@ fn alloc(layout: Layout) -> Result<NonNull<u8>, TryReserveError> {
             .allocate(layout)
             .map_err(|_e| TryReserveError::AllocError {
                 layout,
+                #[cfg(not(feature = "rust_1_57"))]
                 non_exhaustive: (),
             })
             .map(|v| v.cast())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,13 +22,13 @@
 //! can't return a Result to indicate allocation failure.
 
 #![cfg_attr(not(test), no_std)]
-#![cfg_attr(feature = "unstable", feature(try_reserve))]
+#![cfg_attr(all(feature = "unstable", not(feature = "rust_1_57")), feature(try_reserve))]
 #![cfg_attr(feature = "unstable", feature(min_specialization))]
 #![cfg_attr(feature = "unstable", feature(allocator_api))]
 #![cfg_attr(feature = "unstable", feature(dropck_eyepatch))]
 #![cfg_attr(feature = "unstable", feature(ptr_internals))]
 #![cfg_attr(feature = "unstable", feature(core_intrinsics))]
-#![cfg_attr(feature = "unstable", feature(maybe_uninit_ref))]
+#![cfg_attr(all(feature = "unstable", not(feature = "rust_1_57")), feature(maybe_uninit_ref))]
 #![cfg_attr(feature = "unstable", feature(maybe_uninit_slice))]
 #![cfg_attr(feature = "unstable", feature(maybe_uninit_extra))]
 #![cfg_attr(feature = "unstable", feature(maybe_uninit_uninit_array))]
@@ -55,9 +55,9 @@ pub use hashmap::*;
 pub mod format;
 pub mod try_clone;
 
-#[cfg(feature = "unstable")]
+#[cfg(all(feature = "unstable", not(feature = "rust_1_57")))]
 pub use alloc::collections::TryReserveError;
-#[cfg(not(feature = "unstable"))]
+#[cfg(not(all(feature = "unstable", not(feature = "rust_1_57"))))]
 pub use hashbrown::TryReserveError;
 
 #[cfg(feature = "std_io")]
@@ -78,4 +78,14 @@ pub trait TryClone {
     fn try_clone(&self) -> Result<Self, TryReserveError>
     where
         Self: core::marker::Sized;
+}
+
+#[cfg(feature = "rust_1_57")]
+fn make_try_reserve_error(len: usize, additional: usize, elem_size: usize, align: usize) -> hashbrown::TryReserveError {
+    if let Some(size) = len.checked_add(additional).and_then(|l| l.checked_mul(elem_size)) {
+        if let Ok(layout) = alloc::alloc::Layout::from_size_align(size, align) {
+            return TryReserveError::AllocError { layout }
+        }
+    }
+    TryReserveError::CapacityOverflow
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -431,7 +431,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
     }
 }
 
-#[cfg(not(feature = "unstable"))]
+#[cfg(not(any(feature = "unstable", feature = "rust_1_57")))]
 fn vec_try_reserve<T>(v: &mut Vec<T>, additional: usize) -> Result<(), TryReserveError> {
     let available = v.capacity().checked_sub(v.len()).expect("capacity >= len");
     if additional > available {
@@ -449,7 +449,7 @@ fn vec_try_reserve<T>(v: &mut Vec<T>, additional: usize) -> Result<(), TryReserv
     Ok(())
 }
 
-#[cfg(not(feature = "unstable"))]
+#[cfg(not(any(feature = "unstable", feature = "rust_1_57")))]
 fn vec_try_extend<T>(v: &mut Vec<T>, new_cap: usize) -> Result<(), TryReserveError> {
     let old_len = v.len();
     let old_cap: usize = v.capacity();
@@ -498,14 +498,22 @@ fn vec_try_extend<T>(v: &mut Vec<T>, new_cap: usize) -> Result<(), TryReserveErr
 impl<T> FallibleVec<T> for Vec<T> {
     #[inline(always)]
     fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
-        #[cfg(feature = "unstable")]
+        #[cfg(all(feature = "unstable", not(feature = "rust_1_57")))]
         {
             self.try_reserve(additional)
         }
 
-        #[cfg(not(feature = "unstable"))]
+        #[cfg(not(feature = "rust_1_57"))]
         {
             vec_try_reserve(self, additional)
+        }
+
+        #[cfg(feature = "rust_1_57")]
+        {
+            // TryReserveError is an opaque type in 1.57
+            self.try_reserve(additional).map_err(|_| {
+                crate::make_try_reserve_error(self.len(), additional, core::mem::size_of::<T>(), core::mem::align_of::<T>())
+            })
         }
     }
 
@@ -904,7 +912,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "unstable"))]
+    #[cfg(not(any(feature = "unstable", feature = "rust_1_57")))]
     fn try_extend_zst() {
         let mut vec: Vec<()> = Vec::new();
         assert_eq!(vec.capacity(), core::usize::MAX);


### PR DESCRIPTION
Rust 1.57 has stabilized the `try_reserve` feature.

This change:

* Uses "native" `try_reserve` if `rust_1_57` feature is enabled. I haven't added auto-detection, because it'd require a build script.
* Keeps using `hashbrown::TryReserveError`, because it's already a part of the stable API.
* Adds a `std` feature, because `HashMap` isn't in the `alloc` crate.
* Supports a combination of `unstable` and `rust_1_57` to correct for changes in the more recent nightly Rust versions.

I think this change is backwards compatible, and keeps the same MSRV.