### PR TITLE
Make hashmap an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,17 @@ readme = "README.md"
 keywords = ["fallible", "collections"]
 
 [dependencies]
-hashbrown = "0.12.1"
+hashbrown = { version = "0.12.1", optional = true }
 
 [features]
+default = ["hashmap"]
 # Enable on nightly builds to allow use of unstable features
 unstable = []
 # Functionality based on std::io types
 std_io = ["std"]
 # Allow use of std
 std = []
+# Allow use of hashmap
+hashmap = ["hashbrown"]
 # Use fallible functions added in Rust 1.57
 rust_1_57 = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,18 +47,16 @@ pub mod arc;
 pub use arc::*;
 #[cfg(feature = "unstable")]
 pub mod btree;
-#[cfg(not(feature = "unstable"))]
+#[cfg(all(feature = "hashmap", not(feature = "unstable")))]
 pub mod hashmap;
-#[cfg(not(feature = "unstable"))]
+#[cfg(all(feature = "hashmap", not(feature = "unstable")))]
 pub use hashmap::*;
 #[macro_use]
 pub mod format;
 pub mod try_clone;
 
-#[cfg(all(feature = "unstable", not(feature = "rust_1_57")))]
-pub use alloc::collections::TryReserveError;
-#[cfg(not(all(feature = "unstable", not(feature = "rust_1_57"))))]
-pub use hashbrown::TryReserveError;
+pub mod try_reserve_error;
+pub use try_reserve_error::TryReserveError;
 
 #[cfg(feature = "std_io")]
 pub use vec::std_io::*;
@@ -81,7 +79,7 @@ pub trait TryClone {
 }
 
 #[cfg(feature = "rust_1_57")]
-fn make_try_reserve_error(len: usize, additional: usize, elem_size: usize, align: usize) -> hashbrown::TryReserveError {
+fn make_try_reserve_error(len: usize, additional: usize, elem_size: usize, align: usize) -> TryReserveError {
     if let Some(size) = len.checked_add(additional).and_then(|l| l.checked_mul(elem_size)) {
         if let Ok(layout) = alloc::alloc::Layout::from_size_align(size, align) {
             return TryReserveError::AllocError { layout }

--- a/src/try_reserve_error.rs
+++ b/src/try_reserve_error.rs
@@ -1,0 +1,19 @@
+#[cfg(all(feature = "unstable", not(feature = "rust_1_57")))]
+pub use alloc::collections::TryReserveError;
+#[cfg(all(feature = "hashmap", not(all(feature = "unstable", not(feature = "rust_1_57")))))]
+pub use hashbrown::TryReserveError;
+
+/// The error type for `try_reserve` methods.
+#[cfg(all(not(feature = "hashmap"), not(all(feature = "unstable", not(feature = "rust_1_57")))))]
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum TryReserveError {
+    /// Error due to the computed capacity exceeding the collection's maximum
+    /// (usually `isize::MAX` bytes).
+    CapacityOverflow,
+
+    /// The memory allocator returned an error
+    AllocError {
+        /// The layout of the allocation request that failed.
+        layout: alloc::alloc::Layout,
+    },
+}


### PR DESCRIPTION
Make hashmap an optional feature, which makes hashbrown also optional. Closes #32 