### PR TITLE
build: upgrade `hashbrown` 0.13 → 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 keywords = ["fallible", "collections"]
 
 [dependencies]
-hashbrown = { version = "0.13", optional = true }
+hashbrown = { version = "0.14", optional = true }
 
 [features]
 default = ["hashmap"]


### PR DESCRIPTION
Intended to unblock Mozilla's work to upgrade WGPU, which now consumes a `hashbrown`. Firefox resists having duplicate dependencies, and it uses `hashbrown` 0.12. WGPU is already consuming `hashbrown` 0.14.

- See also <https://github.com/mozilla/application-services/pull/6219>.