### PR TITLE
Don't build arc crate on targets without full atomics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,9 @@ pub mod vec;
 pub use vec::*;
 pub mod rc;
 pub use rc::*;
+#[cfg(target_has_atomic = "ptr")]
 pub mod arc;
+#[cfg(target_has_atomic = "ptr")]
 pub use arc::*;
 #[cfg(feature = "unstable")]
 pub mod btree;


### PR DESCRIPTION
This allows building on `thumbv6m-none-eabi`.