### PR TITLE
Upgrade hashbrown, again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["rust-patterns", "memory-management"]
 rust-version = "1.64"
 
 [dependencies]
-hashbrown = { version = "0.14", optional = true }
+hashbrown = { version = "0.15", optional = true }
 
 [features]
 default = ["hashmap"]


### PR DESCRIPTION
hashbrown's type isn't exposed directly, so this should be semver-compatible